### PR TITLE
Timeout after waiting for RTC config for 10 seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,10 @@ function recording (swarm, microphone) {
 }
 
 function getRtcConfig (cb) {
-  xhr('https://instant.io/rtcConfig', function (err, res) {
+  xhr({
+    url: 'https://instant.io/rtcConfig',
+    timeout: 10000
+  }, function (err, res) {
     if (err || res.statusCode !== 200) {
       cb(new Error('Could not get WebRTC config from server. Using default (without TURN).'))
     } else {

--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ function joinRoom (room) {
 
       let swarm = createSwarm(signalHost, {
         stream: output.stream,
-        rtcConfig: rtcConfig
+        config: rtcConfig
       })
       swarm.joinRoom(roomHost, room)
       swarm.on('stream', stream => {


### PR DESCRIPTION
https://instant.io has excellent uptime, but if it's down for some
reason, then the XHR request should fail instantly and the
callback should return right away, allowing roll-call to proceed
without TURN.

This timeout is just for if the server is hung or really slow for some
reason.
