### PR TITLE
Ensure audio fade-in at start begins with 0 gain

### DIFF
--- a/lib/views.js
+++ b/lib/views.js
@@ -82,6 +82,7 @@ exports.audioFile = (file, audio, context) => {
   const button = elem.querySelector('i.play-button')
 
   const play = () => {
+    audio.volume(0)
     audio.fadeVolume(elem.userGain, 0.01)
     audio.seek(0)
     audio.play()


### PR DESCRIPTION
A tweak to accompany mikeal/waudio#1 to ensure that we fade from 0 to userGain when playing an audio file.

(issue re-created because I initially pushed the branch to the wrong clone :smirk:)
