### PR TITLE
Automatic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+
+node_js:
+  - "6"
+
+cache:
+  directories:
+    - node_modules
+
+script:
+  - npm run test
+  - npm run build
+
+after_success:
+  - ./scripts/deploy.sh

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "beefy index.js:bundle.js --index index.html",
+    "build": "browserify index.js > bundle.js",
     "test": "standard"
   },
   "repository": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# based on:
+# - https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
+# - http://www.steveklabnik.com/automatically_update_github_pages_with_travis_example/
+
+set -o errexit -o nounset
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Skipping deploy: pull request."
+  exit 1
+fi
+
+if [ "$TRAVIS_BRANCH" != "master" -a "$TRAVIS_BRANCH" != "stable" ]; then
+  echo "Skipping deploy: branch not master or stable."
+  exit 1
+fi
+
+REV=$(git rev-parse --short HEAD)
+
+copy_assets () { cp -r vendor favicon.png index.html bundle.js $1; }
+
+mkdir ../build
+mkdir ../build/staging
+
+git fetch origin master:remotes/origin/master stable:remotes/origin/stable
+
+git checkout origin/master
+npm run build
+copy_assets ../build/staging
+
+git checkout origin/stable
+npm run build
+copy_assets ../build
+
+cd ../build
+echo "rollcall.audio" > CNAME
+
+git init
+git config user.name "CI"
+git config user.email "ci@rollcall.audio"
+
+git add -A .
+git commit -m "Auto-build of ${REV}"
+git push -f "https://${GH_TOKEN}@${GH_REF}" HEAD:gh-pages > /dev/null 2>&1
+
+echo "✔ Deployed successfully."


### PR DESCRIPTION
Here's a Travis config and build script to run tests and then automatically deploy to GitHub pages, based on the approach described in https://github.com/mikeal/roll-call/issues/33. It deploys master to /staging and the "stable" branch to /.

You can see a demo result of the build process at https://github.com/chromakode/roll-call/tree/gh-pages. Note that the auto-deploy blows away the history of the gh-pages branch each rebuild. This is intentional to keep the overall repository size down.

@mikeal I looked into repository deploy keys, and rediscovered why a separate GitHub user is preferable: deploy keys require SSH keypairs, whereas user personal access tokens can conveniently be added directly into a git push remote URL.

To set this up after merging:
1. Push a copy of master to the "stable" branch
2. Enable Travis for this repo
3. Add [roll-call-ci](https://github.com/roll-call-ci) as a collaborator
4. Gain access to roll-call-ci account (I'll contact about this) and generate a token at https://github.com/settings/tokens
5. Set two private env vars in Travis config: `GH_REF=github.com/mikeal/roll-call.git`, `GH_TOKEN=<roll-call-ci token>`
