### PR TITLE
fix: added gif from medium to make text below valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Roll Call
 
+![demo gif](https://cdn-images-1.medium.com/max/600/1*PPYEQEBH_KFuifS0EEdazg.gif)
+
 On the surface, **Roll Call is quite simple**. Free calls for everyone in the world.
 
 Try it now at: [rollcall.audio](https://rollcall.audio)


### PR DESCRIPTION
Text below speaks of a gif, the non-Medium version on GitHub was missing the gif file.